### PR TITLE
Add HTTPS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ This tool has a couple of advantages over the simple version:
 
 Help Menu:
 ```
-usage: up [-h] [-v] [-q] [-p PORT] [-i IP] [-m MSG] [--proxies PROXIES]
+usage: up [-h] [-v] [-q] [-p PORT] [-i IP] [--https | --no-https] 
+          [--cert CERT] [--key KEY] [-m MSG] [--proxies PROXIES]
           [-o OUTPUT] [--ignore IGNORE] [-d DIRECTORY | --no-serve]
           [--accessible | -c] [-ec]
 
@@ -24,6 +25,9 @@ options:
   -p PORT, --port PORT  The port to serve on. Defaults to port 80
   -i IP, --ip IP        The IP to serve on. Defaults to all interfaces
                         (0.0.0.0)
+  --https, --no-https   Run HTTPS server.
+  --cert CERT           Path to the certificate file.
+  --key KEY             Path to the key file.
   -m MSG, --msg MSG     Message to respond to non-GET requests with. Defaults
                         to ''.
   --proxies PROXIES     Number of proxies in front of the tool. Defaults to 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 flask
 netifaces
-waitress
 rich
+cryptography

--- a/up
+++ b/up
@@ -7,7 +7,6 @@ import argparse
 import os
 import json
 import re
-import sys
 import waitress
 import random
 import netifaces

--- a/up
+++ b/up
@@ -7,17 +7,17 @@ import argparse
 import os
 import json
 import re
-import waitress
 import random
 import netifaces
 import colorsys
 import threading
+import logging
 from rich.console import Console
 from rich.columns import Columns
 from rich.table import Table
 from datetime import datetime
 from werkzeug.middleware.proxy_fix import ProxyFix
-from flask import Flask, send_from_directory, request
+from flask import Flask, send_from_directory, request, cli
 
 
 
@@ -261,6 +261,7 @@ class ServerConfig():
     def __init__(self, **kwargs):
         self.verbose = True
         self.port = 80
+        self.ssl_context = None
         self.msg = ""
         self.directory = os.getcwd()
         self.output = None
@@ -274,6 +275,13 @@ class ServerConfig():
         for i in kwargs.items():
             if hasattr(self, i[0]):
                 setattr(self, i[0], i[1])
+
+        # Check ssl related args and set ssl context
+        if kwargs.get("https"):
+            if kwargs.get("cert") and kwargs.get("key"):
+                self.ssl_context = (kwargs.get("cert"), kwargs.get("key"))
+            else:
+                self.ssl_context = "adhoc"
 
 
         # Accessible means that colour should be disabled as well
@@ -446,9 +454,17 @@ class UpServer():
             
         if not quiet:
             self.printInfo(quiet=True)
-            print(f"Serving on http://{self.interfaces.workingIP}:{self.config.port}")
+            if not self.config.ssl_context:
+                proto = "http"
+            else:
+                proto = "https"
+            print(f"Serving on {proto}://{self.interfaces.workingIP}:{self.config.port}")
 
-        threading.Thread(target=lambda: waitress.serve(workingApp, port=self.config.port, host=self.interfaces.workingIP), daemon=True).start() # Run the HTTP server in the background so that the enter-for-info works
+        # Disable flask logging
+        logging.getLogger('werkzeug').disabled = True
+        cli.show_server_banner = lambda *args: None
+
+        threading.Thread(target=lambda: workingApp.run(port=self.config.port, host=self.interfaces.workingIP, ssl_context=self.config.ssl_context), daemon=True).start() # Run the HTTP server in the background so that the enter-for-info works
         while True:
             try:
                 input()
@@ -487,6 +503,9 @@ def parseUpArgs(interfaces: Interfaces) -> argparse.Namespace:
     parser.add_argument("-q", "--quiet", help="Don't show information on startup", action="store_true")
     parser.add_argument("-p", "--port", help="The port to serve on. Defaults to port 80", default=80)
     parser.add_argument("-i", "--ip", help="The IP to serve on. Defaults to all interfaces (0.0.0.0)", default="0.0.0.0", type=lambda addr: validAddress(interfaces, addr))
+    parser.add_argument("--https", help="Run HTTPS server.", action=argparse.BooleanOptionalAction)
+    parser.add_argument("--cert", help="Path to the certificate file.", default=None)
+    parser.add_argument("--key", help="Path to the key file.", default=None)
     parser.add_argument("-m", "--msg", help="Message to respond to non-GET requests with. Defaults to ''.", default="")
     parser.add_argument("--proxies", help="Number of proxies in front of the tool. Defaults to 0", type=positiveInt, default=0)
     parser.add_argument("-o","--output", help="Directory to output request data to. Disabled by default")


### PR DESCRIPTION
This pull request adds HTTPS support to `up`.

The tool can now be launched with `--https` to run with self-signed adhoc certificate.
Alternatively, you can pass `--https`, `--cert path/to/cert.file`, and `--key path/to/key.file` to run your own certs.

Changes:
* suppressed Flask debug output
* removed `waitress` import and requirement
* replaced WSGI from `waitress` to inbuilt Werkzeug
* removed `sys` import (unused)
* added `cryptography` to requirements.txt -- required for adhoc certs
* added 3 args -- `--https`, `--cert`, `--key`
* added logic to parse these args in `ServerConfig` class

Note: no checks on if file cert files exist are running. You get OS exception `FileNotFound`